### PR TITLE
Add stdlib context

### DIFF
--- a/command.go
+++ b/command.go
@@ -145,7 +145,12 @@ func WithEnvironmentVariables(env EnvVars) func(c *Command) {
 	}
 }
 
+// WithContext adds context.Context to the command. Context timeout/deadline
+// is favored over Timeout
 func WithContext(ctx context.Context) func(c *Command) {
+	if ctx == nil {
+		panic("nil context")
+	}
 	return func(c *Command) {
 		c.ctx = ctx
 	}
@@ -219,10 +224,7 @@ func (c *Command) Execute() error {
 
 	done := make(chan error, 1)
 	go func() {
-		select {
-		case done <- cmd.Wait():
-			return
-		}
+		done <- cmd.Wait()
 	}()
 
 	select {
@@ -239,7 +241,6 @@ func (c *Command) Execute() error {
 			c.getExitCode(err)
 		}
 	}
-
 	c.executed = true
 	return nil
 }

--- a/command_test.go
+++ b/command_test.go
@@ -133,12 +133,14 @@ func TestCommand_SetOptions(t *testing.T) {
 }
 
 func TestCommand_WithContext(t *testing.T) {
-	// Ensure context is favored over WithTimeout
+	// ensure legacy timeout is honored
 	cmd := NewCommand("sleep 3;", WithTimeout(1*time.Second))
 	err := cmd.Execute()
 	assert.NotNil(t, err)
 	assert.Equal(t, "Command timed out after 1s", err.Error())
 
+	// set context timeout to 2 seconds to ensure
+	// context takes precedence over timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	err = cmd.ExecuteContext(ctx)

--- a/command_test.go
+++ b/command_test.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"os"
 	"runtime"
@@ -130,20 +129,4 @@ func TestCommand_SetOptions(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, time.Duration(1000000000), c.Timeout)
 	assertEqualWithLineBreak(t, "test", writer.String())
-}
-
-func TestCommand_WithContext(t *testing.T) {
-	// ensure legacy timeout is honored
-	cmd := NewCommand("sleep 3;", WithTimeout(1*time.Second))
-	err := cmd.Execute()
-	assert.NotNil(t, err)
-	assert.Equal(t, "Command timed out after 1s", err.Error())
-
-	// set context timeout to 2 seconds to ensure
-	// context takes precedence over timeout
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-	err = cmd.ExecuteContext(ctx)
-	assert.NotNil(t, err)
-	assert.Equal(t, "context deadline exceeded", err.Error())
 }

--- a/command_test.go
+++ b/command_test.go
@@ -133,12 +133,15 @@ func TestCommand_SetOptions(t *testing.T) {
 }
 
 func TestCommand_WithContext(t *testing.T) {
+	// Ensure context is favored over WithTimeout
+	cmd := NewCommand("sleep 3;", WithTimeout(1*time.Second))
+	err := cmd.Execute()
+	assert.NotNil(t, err)
+	assert.Equal(t, "Command timed out after 1s", err.Error())
+
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	// WithContext is favored over Timeout
-	cmd := NewCommand("sleep 3;", WithContext(ctx), WithTimeout(1*time.Second))
-
-	err := cmd.Execute()
+	err = cmd.ExecuteContext(ctx)
 	assert.NotNil(t, err)
 	assert.Equal(t, "context deadline exceeded", err.Error())
 }

--- a/command_test.go
+++ b/command_test.go
@@ -2,12 +2,14 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"os"
 	"runtime"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCommand_NewCommand(t *testing.T) {
@@ -128,4 +130,15 @@ func TestCommand_SetOptions(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, time.Duration(1000000000), c.Timeout)
 	assertEqualWithLineBreak(t, "test", writer.String())
+}
+
+func TestCommand_WithContext(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	// WithContext is favored over Timeout
+	cmd := NewCommand("sleep 3;", WithContext(ctx), WithTimeout(1*time.Second))
+
+	err := cmd.Execute()
+	assert.NotNil(t, err)
+	assert.Equal(t, "context deadline exceeded", err.Error())
 }

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,7 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
closes #20 

Initial goal is to ensure that both the input and outputs do not change allowing for v1 to be maintained.

Experiment of implementing command with context.

I personally don't know if there is a major benefit to using context, besides that it is the standard for timeouts within the community. It also allows users of this package a bit more control over the timeout of an entire system. An example being a `Command` that is triggered by a REST endpoint where the REST endpoint sets the `context.Context` `deadline` or `timeout`. In short the caller is trying to do many things with same context flowing through their system.

The following includes commits that implements context by adding it to the beginning of the function signature and using the `WithContect(context.Context)` pattern. I personally like the `ExecuteContext(context)` pattern as it matches the ecosystem and the maintainers  of `context` recommend it. Also FWIW it seems a bit cleaner to me. 

In order to ensure backwards compatibility I elected to not use [`exec.CommandContext`](https://pkg.go.dev/os/exec#CommandContext) as it would not allow us to get the process id of the failed command after a timeout. Line [#217](https://github.com/commander-cli/cmd/pull/21/files#diff-4d7d1923693fc5ce892add2ea2907a744e77ea0b50c1939ccc5067cb48a466a3R217) demonstrates this. This package should report the process that it fails to kill on timeout in my opinion, it seems like a natural error to return. 

```golang
	select {
	case <-ctx.Done():
		if err := cmd.Process.Kill(); err != nil {
			return fmt.Errorf("Timeout occurred and can not kill process with pid %v", cmd.Process.Pid)
		}
		if c.Timeout != 0 && !hasDeadline {
			return fmt.Errorf("Command timed out after %v", c.Timeout)
		}
		return ctx.Err()
```

The check above also demonstrates that we are maintaining backwards compatibility with `Timeout`. 

