### PR TITLE
Add option WithCustomBaseCommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ To configure the command a option function will be passed which receives the com
 
 Default option functions:
 
+ - `cmd.WithCustomBaseCommand(*exec.Cmd)`
  - `cmd.WithStandardStreams`
  - `cmd.WithCustomStdout(...io.Writers)`
  - `cmd.WithCustomStderr(...io.Writers)`

--- a/command.go
+++ b/command.go
@@ -72,6 +72,17 @@ func NewCommand(cmd string, options ...func(*Command)) *Command {
 	return c
 }
 
+// WithCustomBaseCommand allows the OS specific generated baseCommand
+// to be overridden by an *os/exec.Cmd.
+//
+// Example:
+//
+//      c := cmd.NewCommand(
+//        "echo hello",
+//        cmd.WithCustomBaseCommand(exec.Command("/bin/bash", "-c")),
+//      )
+//      c.Execute()
+//
 func WithCustomBaseCommand(baseCommand *exec.Cmd) func(c *Command) {
 	return func(c *Command) {
 		baseCommand.Args = append(baseCommand.Args, c.Command)

--- a/command_darwin_test.go
+++ b/command_darwin_test.go
@@ -1,10 +1,25 @@
 package cmd
 
 import (
-	"github.com/stretchr/testify/assert"
+	"os/exec"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
+
+func TestCommand_WithCustomBaseCommand(t *testing.T) {
+	cmd := NewCommand(
+		"echo $0",
+		WithCustomBaseCommand(exec.Command("/bin/bash", "-c")),
+	)
+
+	err := cmd.Execute()
+	assert.Nil(t, err)
+	// on darwin we use /bin/sh by default test if we're using bash
+	assert.NotEqual(t, "/bin/sh\n", cmd.Stdout())
+	assert.Equal(t, "/bin/bash\n", cmd.Stdout())
+}
 
 func TestCommand_ExecuteStderr(t *testing.T) {
 	cmd := NewCommand(">&2 echo hello")

--- a/command_linux_test.go
+++ b/command_linux_test.go
@@ -152,6 +152,7 @@ func TestCommand_WithContext(t *testing.T) {
 	// context takes precedence over timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
+	cmd = NewCommand("sleep 3;", WithTimeout(1*time.Second))
 	err = cmd.ExecuteContext(ctx)
 	assert.NotNil(t, err)
 	assert.Equal(t, "context deadline exceeded", err.Error())


### PR DESCRIPTION
close #27 

Add the ability for client to use their own os/exec command. 

I'm not sure if this is in the spirit of this package, but I thought it would be interesting to implement. 🤷‍♂️ 

I'm very much on the fence..